### PR TITLE
Modify EXINT driver

### DIFF
--- a/os/hal/boards/AT_START_F405/board.c
+++ b/os/hal/boards/AT_START_F405/board.c
@@ -67,7 +67,7 @@ typedef struct {
 } gpio_config_t;
 
 /**
- * @brief   STM32 GPIO static initialization data.
+ * @brief   AT32 GPIO static initialization data.
  */
 static const gpio_config_t gpio_default_config = {
 #if AT32_HAS_GPIOA

--- a/os/hal/ports/AT32/AT32F405xx/at32_isr.c
+++ b/os/hal/ports/AT32/AT32F405xx/at32_isr.c
@@ -41,7 +41,7 @@
 /* Driver local functions.                                                   */
 /*===========================================================================*/
 
-#define exti_serve_irq(intsts, channel) {                                       \
+#define exint_serve_irq(intsts, channel) {                                       \
                                                                             \
   if ((intsts) & (1U << (channel))) {                                           \
     _pal_isr_code(channel);                                                 \

--- a/os/hal/ports/AT32/LLD/EXINTv1/at32_exint.h
+++ b/os/hal/ports/AT32/LLD/EXINTv1/at32_exint.h
@@ -112,11 +112,11 @@ typedef uint32_t exintmode_t;
  * @special
  */
 #define exintGetAndClearGroup1(mask, out) do {                              \
-  uint32_t intsts;                                                          \
+  uint32_t intsts1;                                                          \
                                                                             \
-  intsts = EXINT->INTSTS & (mask);                                          \
-  (out) = intsts;                                                           \
-  EXINT->INTSTS = intsts;                                                   \
+  intsts1 = EXINT->INTSTS & (mask);                                          \
+  (out) = intsts1;                                                           \
+  EXINT->INTSTS = intsts1;                                                   \
 } while (false)
 
 /*===========================================================================*/


### PR DESCRIPTION
1. Modifying the exint serve irq name
2. Modifying the exint variable with the same name results in a compilation error